### PR TITLE
fix darktide command name

### DIFF
--- a/bot/cogs/misc_games.py
+++ b/bot/cogs/misc_games.py
@@ -18,7 +18,7 @@ class Misc_games(commands.Cog, name="misc_games"):
         await ctx.send(file=discord.File("images/eft.png"))
 
     @commands.command(name="darktide")
-    async def eft(self, ctx):
+    async def darktide(self, ctx):
         await ctx.send(file=discord.File("images/darktide.png"))
 
 async def setup(bot):


### PR DESCRIPTION
The function name for command `darktide` was incorrectly named `eft` which caused a conflict with the actual `eft` command preventing it from working 