### PR TITLE
fix: sanitize Discord mentions in !random output to prevent pings

### DIFF
--- a/bot/cogs/random_msg.py
+++ b/bot/cogs/random_msg.py
@@ -17,10 +17,13 @@ class RandomMsg(commands.Cog, name="random_msg"):
     def _build_regex(term: str) -> re.Pattern:
         starts_wild = term.startswith('*')
         ends_wild = term.endswith('*')
+        stripped = term.strip('*')
         parts = [re.escape(p) for p in term.split('*')]
         core = r'\w*'.join(parts)
-        prefix = '' if starts_wild else r'\b'
-        suffix = '' if ends_wild else r'\b'
+        first_char = stripped[:1]
+        last_char = stripped[-1:]
+        prefix = '' if starts_wild else (r'\b' if first_char and (first_char.isalnum() or first_char == '_') else '')
+        suffix = '' if ends_wild else (r'\b' if last_char and (last_char.isalnum() or last_char == '_') else '')
         return re.compile(rf'{prefix}{core}{suffix}', re.IGNORECASE)
 
     def _sanitize_mentions(self, content: str, channel_id: int) -> str:

--- a/bot/cogs/random_msg.py
+++ b/bot/cogs/random_msg.py
@@ -6,6 +6,7 @@ import discord
 from discord.ext import commands
 
 DB_PATH = "/data/markov.db"
+MENTION_RE = re.compile(r'<@!?(\d+)>')
 
 
 class RandomMsg(commands.Cog, name="random_msg"):
@@ -21,6 +22,18 @@ class RandomMsg(commands.Cog, name="random_msg"):
         prefix = '' if starts_wild else r'\b'
         suffix = '' if ends_wild else r'\b'
         return re.compile(rf'{prefix}{core}{suffix}', re.IGNORECASE)
+
+    def _sanitize_mentions(self, content: str, channel_id: int) -> str:
+        def replace(match):
+            user_id = int(match.group(1))
+            conn = sqlite3.connect(DB_PATH)
+            row = conn.execute(
+                "SELECT username FROM messages WHERE user_id = ? AND channel_id = ? LIMIT 1",
+                (user_id, channel_id),
+            ).fetchone()
+            conn.close()
+            return f'@{row[0]}' if row else f'@{user_id}'
+        return MENTION_RE.sub(replace, content)
 
     def _resolve_user_id(self, target: str, channel_id: int) -> Optional[int]:
         conn = sqlite3.connect(DB_PATH)
@@ -77,6 +90,7 @@ class RandomMsg(commands.Cog, name="random_msg"):
         conn.close()
 
         display_name = nick_row[0] if nick_row else username
+        content = self._sanitize_mentions(content, channel_id)
         return content, display_name
 
     @commands.command(name="random")

--- a/tests/test_random_msg.py
+++ b/tests/test_random_msg.py
@@ -56,6 +56,16 @@ class TestBuildRegex:
         p = RandomMsg._build_regex("Dragon")
         assert p.search("the dragon sleeps")
 
+    def test_discord_emoji(self):
+        p = RandomMsg._build_regex("<:smile:111222333444>")
+        assert p.search("haha <:smile:111222333444> lol")
+        assert not p.search("nothing here")
+
+    def test_discord_mention_format(self):
+        p = RandomMsg._build_regex("<@999888777>")
+        assert p.search("hey <@999888777> check this")
+        assert not p.search("nothing here")
+
 
 class TestFetchRandom:
     def test_no_term_returns_row(self, db, cog):
@@ -111,13 +121,15 @@ class TestFetchRandom:
         result = cog._fetch_random(CHANNEL, "@alice")
         assert result is not None
         content, _ = result
-        assert f"<@{ALICE_ID}>" in content
+        assert "@alice" in content
+        assert f"<@{ALICE_ID}>" not in content
 
     def test_mention_via_nickname(self, db, cog):
         result = cog._fetch_random(CHANNEL, "@ally")
         assert result is not None
         content, _ = result
-        assert f"<@{ALICE_ID}>" in content
+        assert "@alice" in content
+        assert f"<@{ALICE_ID}>" not in content
 
     def test_mention_unknown_user(self, db, cog):
         result = cog._fetch_random(CHANNEL, "@nobody")


### PR DESCRIPTION
Replace <@user_id> patterns in message content with plain text @username before posting. AllowedMentions.none() alone was insufficient -- Discord still resolved and pinged users when the stored content contained raw mention syntax.

Lookup username from messages table by user_id. Falls back to @id if user is not found in the database.