### PR TITLE
fix: load cogs in setup_hook so task loops run in the correct event loop

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,5 +1,4 @@
 import discord
-import asyncio
 import platform
 import os
 from bot import constants
@@ -53,9 +52,4 @@ async def on_command_completion(context: Context) -> None:
         )
 
 
-async def load_cogs() -> None:
-    await rankaisijaBot.load_cogs()
-
-
-asyncio.run(load_cogs())
 rankaisijaBot.run(constants.Bot.token)

--- a/bot/rankaisija.py
+++ b/bot/rankaisija.py
@@ -8,6 +8,9 @@ class Rankaisija(Bot):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    async def setup_hook(self):
+        await self.load_cogs()
+
     async def load_cogs(self):
         for cog in constants.Cog.cogs:
             try:


### PR DESCRIPTION
asyncio.run(load_cogs()) created tasks in a temporary event loop that was closed before the bot connected, causing session_reminder and nightly_rebuild to never run. Moving cog loading to setup_hook fixes this.