### PR TITLE
fix: use 13:37 in example time

### DIFF
--- a/bot/cogs/notify.py
+++ b/bot/cogs/notify.py
@@ -105,7 +105,7 @@ class Notify(commands.Cog, name="reminders"):
         """Aseta muistutus.
 
         Muodot:
-        !notify 13:30 <viesti>           – seuraavan kerran kun kello on 13:30
+        !notify 13:37 <viesti>           – seuraavan kerran kun kello on 13:37
         !notify tomorrow 13:30 <viesti>  – huomenna klo 13:30
         !notify 24.7. 13:30 <viesti>     – tiettynä päivämääränä
         !notify 24.7.2026 13:30 <viesti> – tiettynä päivämääränä (eksplisiittinen vuosi)


### PR DESCRIPTION
Closes #37

## Summary
- Changed example time in `!notify` help text from `13:30` to `13:37`

## Test plan
- [ ] Run `!help notify` and verify example shows `13:37`